### PR TITLE
Fix for platform socklen_t on other C libraries than glibc

### DIFF
--- a/mkspecs/linux-g++/qplatformdefs.h
+++ b/mkspecs/linux-g++/qplatformdefs.h
@@ -86,10 +86,10 @@
 
 #undef QT_SOCKLEN_T
 
-#if defined(__GLIBC__) && (__GLIBC__ >= 2)
-#define QT_SOCKLEN_T            socklen_t
-#else
+#if defined(__GLIBC__) && (__GLIBC__ < 2)
 #define QT_SOCKLEN_T            int
+#else
+#define QT_SOCKLEN_T            socklen_t
 #endif
 
 #if defined(_XOPEN_SOURCE) && (_XOPEN_SOURCE >= 500)


### PR DESCRIPTION
This helps to make sure that `QT_SOCKLEN_T` is defined to be `int` only when its glibc < 2 and not also for the libraries which may define it as per standards but are not glibc, e.g. musl.

This patch is adapted from https://github.com/qtproject/qtbase/commit/813f468a14fb84af43c1f8fc0a1430277358eba2.
