### PR TITLE
Enhancements for Compiling Qt 4.8 with g++ 11 on AlmaLinux 9

### DIFF
--- a/src/corelib/global/qglobal.h
+++ b/src/corelib/global/qglobal.h
@@ -2493,11 +2493,17 @@ public:
     typename T::const_iterator i, e;
 };
 
+#if defined(__GNUC__) && (__GNUC__ >= 9)
+#define QT_INNER_FOR_BREAK  continue
+#else
+#define QT_INNER_FOR_BREAK  break
+#endif
+
 #define Q_FOREACH(variable, container)                                \
 for (QForeachContainer<__typeof__(container)> _container_(container); \
      !_container_.brk && _container_.i != _container_.e;              \
      __extension__  ({ ++_container_.brk; ++_container_.i; }))                       \
-    for (variable = *_container_.i;; __extension__ ({--_container_.brk; continue;}))
+    for (variable = *_container_.i;; __extension__ ({--_container_.brk; QT_INNER_FOR_BREAK;}))
 
 #else
 

--- a/src/corelib/global/qglobal.h
+++ b/src/corelib/global/qglobal.h
@@ -2497,7 +2497,7 @@ public:
 for (QForeachContainer<__typeof__(container)> _container_(container); \
      !_container_.brk && _container_.i != _container_.e;              \
      __extension__  ({ ++_container_.brk; ++_container_.i; }))                       \
-    for (variable = *_container_.i;; __extension__ ({--_container_.brk; break;}))
+    for (variable = *_container_.i;; __extension__ ({--_container_.brk; continue;}))
 
 #else
 

--- a/src/plugins/accessible/widgets/itemviews.cpp
+++ b/src/plugins/accessible/widgets/itemviews.cpp
@@ -393,7 +393,7 @@ bool QAccessibleTable2::unselectColumn(int column)
     QModelIndex index = view()->model()->index(0, column, view()->rootIndex());
     if (!index.isValid() || view()->selectionMode() & QAbstractItemView::NoSelection)
         return false;
-    view()->selectionModel()->select(index, QItemSelectionModel::Columns & QItemSelectionModel::Deselect);
+    view()->selectionModel()->select(index, QFlags(QItemSelectionModel::Columns) & QItemSelectionModel::Deselect);
     return true;
 }
 

--- a/src/plugins/accessible/widgets/itemviews.cpp
+++ b/src/plugins/accessible/widgets/itemviews.cpp
@@ -393,7 +393,7 @@ bool QAccessibleTable2::unselectColumn(int column)
     QModelIndex index = view()->model()->index(0, column, view()->rootIndex());
     if (!index.isValid() || view()->selectionMode() & QAbstractItemView::NoSelection)
         return false;
-    view()->selectionModel()->select(index, QFlags(QItemSelectionModel::Columns) & QItemSelectionModel::Deselect);
+    view()->selectionModel()->select(index, QFlags<QItemSelectionModel::SelectionFlag>(QItemSelectionModel::Columns) & QItemSelectionModel::Deselect);
     return true;
 }
 

--- a/tools/linguist/linguist/messagemodel.cpp
+++ b/tools/linguist/linguist/messagemodel.cpp
@@ -183,7 +183,7 @@ static int calcMergeScore(const DataModel *one, const DataModel *two)
         if (ContextItem *c = one->findContext(oc->context())) {
             for (int j = 0; j < oc->messageCount(); ++j) {
                 MessageItem *m = oc->messageItem(j);
-                if (c->findMessage(m->text(), m->comment()) >= 0)
+                if (m && c->findMessage(m->text(), m->comment()) )
                     ++inBoth;
             }
         }


### PR DESCRIPTION
I have made minor adjustments in the 3 parts of the source to enable the compilation of Qt 4.8 on AlmaLinux 9 using g++ 11. This update is crucial for our institute, as we rely on an older application that utilizes QtRoot, which requires Qt 4 for compatibility.

We would greatly appreciate it if time could be allocated to review and merge these changes into the main branch. While I understand that Qt 4 is no longer maintained, and this merge request might be overlooked, the integration of these changes would be immensely beneficial for our ongoing projects.

Thank you for your consideration.